### PR TITLE
ci: Add Brakeman security scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,22 +6,7 @@ on:
     branches: [ main ]
 
 jobs:
-  scan_ruby:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: .ruby-version
-          bundler-cache: true
-
-      - name: Scan for common Rails security vulnerabilities using static analysis
-        run: bin/brakeman --no-pager
-
+  # 1) Lint job with RuboCop
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -37,6 +22,7 @@ jobs:
       - name: Lint code for consistent style
         run: bin/rubocop -f github
 
+  # 2) Test job with Minitest
   test:
     runs-on: ubuntu-latest
 
@@ -75,3 +61,23 @@ jobs:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
           # REDIS_URL: redis://localhost:6379/0
         run: bin/rails db:test:prepare test
+
+  # 3) Security job with Brakeman      
+  security:
+    name: Brakeman Scan
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.4.1
+          bundler-cache: true
+
+      - name: Install Brakeman
+        run: bundle install --jobs 4 --retry 3
+
+      - name: Run Brakeman
+        run: bundle exec brakeman --exit-on-warn


### PR DESCRIPTION
Added:
1. Security job with Brakeman - Set job dependencies (runs after lint and test)
2. exit-on-warn flag for strict security checks

Close #9